### PR TITLE
[patch] Adopt resilient image publication

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.title, 'skip-release')
-    uses: libops/.github/.github/workflows/bump-release.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+    uses: libops/.github/.github/workflows/bump-release.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
     with:
       workflow_file: goreleaser.yaml
     permissions:

--- a/.github/workflows/lint-test-build-push.yml
+++ b/.github/workflows/lint-test-build-push.yml
@@ -101,7 +101,7 @@ jobs:
     needs:
       - test
       - image-check
-    uses: libops/.github/.github/workflows/pr-status.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+    uses: libops/.github/.github/workflows/pr-status.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
     permissions: {}
     with:
       needs-json: ${{ toJSON(needs) }}
@@ -109,14 +109,14 @@ jobs:
   publish:
     if: github.event_name != 'pull_request'
     needs: test
-    uses: libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+    uses: libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
     with:
       ref: ${{ github.sha }}
       expected-main-sha: ${{ github.ref == 'refs/heads/main' && github.sha || '' }}
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
     permissions:
       contents: read
       id-token: write

--- a/ci/publication_contract_test.go
+++ b/ci/publication_contract_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-const sharedWorkflowSHA = "578137212ead4ab4059e95df17fa30e9b7ac4aed"
+const sharedWorkflowSHA = "8e27d95846671a9e319f1900e86a488a1d4f39b3"
 
 func repositoryRoot(t *testing.T) string {
 	t.Helper()


### PR DESCRIPTION
## Summary

- advance release, required-status, and image publication callers to the verified shared workflow revision
- align the repository publication contract with the WIF allowlist
- preserve GHCR plus GAR publication, scanning, signing, and exact-main guards

## Validation

- `go test ./ci`
- `actionlint`
- hosted CI is authoritative for the full test and native image smoke matrix