### PR TITLE
[patch] Advance shared publisher workflow

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.title, 'skip-release')
-    uses: libops/.github/.github/workflows/bump-release.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
+    uses: libops/.github/.github/workflows/bump-release.yaml@d5a29840172a53729c5999832534de65b7ba9587
     with:
       workflow_file: goreleaser.yaml
     permissions:

--- a/.github/workflows/lint-test-build-push.yml
+++ b/.github/workflows/lint-test-build-push.yml
@@ -101,7 +101,7 @@ jobs:
     needs:
       - test
       - image-check
-    uses: libops/.github/.github/workflows/pr-status.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
+    uses: libops/.github/.github/workflows/pr-status.yaml@d5a29840172a53729c5999832534de65b7ba9587
     permissions: {}
     with:
       needs-json: ${{ toJSON(needs) }}
@@ -109,14 +109,14 @@ jobs:
   publish:
     if: github.event_name != 'pull_request'
     needs: test
-    uses: libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
+    uses: libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
     with:
       ref: ${{ github.sha }}
       expected-main-sha: ${{ github.ref == 'refs/heads/main' && github.sha || '' }}
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
     permissions:
       contents: read
       id-token: write

--- a/ci/publication_contract_test.go
+++ b/ci/publication_contract_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-const sharedWorkflowSHA = "8e27d95846671a9e319f1900e86a488a1d4f39b3"
+const sharedWorkflowSHA = "d5a29840172a53729c5999832534de65b7ba9587"
 
 func repositoryRoot(t *testing.T) string {
 	t.Helper()


### PR DESCRIPTION
Pins the release, required-status, image publication, and signing identity contracts to the reviewed cleanup-safe shared workflow revision.

No permissions or publication behavior are relaxed. Local actionlint, race tests, module verification, tidy diff, and publication contracts pass.