### PR TITLE
[patch] Align publisher with applied identity

### DIFF
--- a/.github/workflows/lint-test-build-push.yml
+++ b/.github/workflows/lint-test-build-push.yml
@@ -109,14 +109,14 @@ jobs:
   publish:
     if: github.event_name != 'pull_request'
     needs: test
-    uses: libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
+    uses: libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
     with:
       ref: ${{ github.sha }}
       expected-main-sha: ${{ github.ref == 'refs/heads/main' && github.sha || '' }}
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
     permissions:
       contents: read
       id-token: write

--- a/ci/publication_contract_test.go
+++ b/ci/publication_contract_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 )
 
-const sharedWorkflowSHA = "d5a29840172a53729c5999832534de65b7ba9587"
+const (
+	sharedPublisherSHA = "8e27d95846671a9e319f1900e86a488a1d4f39b3"
+	sharedWorkflowSHA  = "d5a29840172a53729c5999832534de65b7ba9587"
+)
 
 func repositoryRoot(t *testing.T) string {
 	t.Helper()
@@ -31,7 +34,7 @@ func readFile(t *testing.T, path ...string) string {
 func TestPublicationUsesSharedGHCRAndGARContract(t *testing.T) {
 	workflow := readFile(t, ".github", "workflows", "lint-test-build-push.yml")
 	for _, required := range []string{
-		"libops/.github/.github/workflows/build-push.yaml@" + sharedWorkflowSHA,
+		"libops/.github/.github/workflows/build-push.yaml@" + sharedPublisherSHA,
 		"libops/.github/.github/workflows/pr-status.yaml@" + sharedWorkflowSHA,
 		"\n  build-push:\n",
 		"image-check:",
@@ -48,7 +51,7 @@ func TestPublicationUsesSharedGHCRAndGARContract(t *testing.T) {
 		"expected-main-sha:",
 		"scan: true",
 		"sign: true",
-		"certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@" + sharedWorkflowSHA,
+		"certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@" + sharedPublisherSHA,
 		"GCLOUD_OIDC_POOL: ${{ secrets.GCLOUD_OIDC_POOL }}",
 		"GSA: ${{ secrets.GSA }}",
 	} {


### PR DESCRIPTION
## Summary
- pin the signed dual-registry image publisher to the immutable shared-workflow revision already authorized by the applied WIF provider
- keep the certificate identity and publication contract tests aligned
- retain newer revisions for unrelated shared workflow callers

## Validation
- focused publication contract tests
- actionlint
- git diff --check