### PR TITLE
Resume interrupted KMS-backed Vault bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,24 @@ Vault accepting `/v1/sys/init` and the "Initialization complete" log entry.
 Every run that finds Vault already initialized verifies the encrypted recovery
 bundle, proves that it contains no root token, validates the bootstrap marker,
 and fails if the legacy `root-token.enc` object exists. A crash after the
-recovery bundle becomes durable but before audit/root revocation completes
-requires a recovery-key-quorum operator repair; an automated retry cannot and
-must not recover a durable root token. If `unseal-keys.json.enc` or
-`bootstrap-complete.json` is missing, the process exits nonzero rather than
-silently claiming success. The
+recovery bundle becomes durable but before audit/root revocation completes is
+resumed automatically when the bundle is protected only by KMS. The retry
+decrypts the root-token-free recovery shares, generates a temporary root token,
+enables and verifies audit, revokes every other root-policy token left by the
+interrupted bootstrap, revokes and verifies the temporary token, and only then
+writes `bootstrap-complete.json`. This recovery is fail-closed: it is refused
+when the completion object already exists, the recovery bundle is missing,
+empty, malformed, or retains a root token, the legacy `root-token.enc` object
+exists, or PGP custodian custody is configured. PGP-protected shares still
+require the configured custodian quorum. Audit setup itself uses a bounded retry
+to bridge transient Vault startup failures while the initial token remains only
+in process memory. The
 default Cloud Run Job policy [retries a failed task three
 times](https://cloud.google.com/run/docs/configuring/max-retries). Those retries
-can bridge transient GCS errors, but they cannot repair a missing recovery
-bundle. Configure a task timeout long enough for the post-initialization retry
-loop because forced termination or task timeout can still interrupt secure
-bootstrap.
+can bridge transient Vault, KMS, and GCS errors, but they cannot repair a
+missing recovery bundle. Configure a task timeout long enough for the
+post-initialization retry loop because forced termination or task timeout can
+still interrupt secure bootstrap.
 
 For auto-unseal, the default is five recovery shares with a threshold of three.
 By default Vault returns those shares to the initializer, which removes the

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ const (
 	secretWriteTimeout          = 2 * time.Minute
 	maxSecretRetryDelay         = time.Minute
 	maxEncryptedBundle          = 256 << 10
+	maxAuditAttempts            = 5
 )
 
 type secretEncrypter func(context.Context, []byte) ([]byte, error)
@@ -109,6 +110,32 @@ type bootstrapCompletion struct {
 type auditDevice struct {
 	Type    string            `json:"type"`
 	Options map[string]string `json:"options"`
+}
+
+type rootGenerationStatus struct {
+	Started      bool   `json:"started"`
+	Nonce        string `json:"nonce"`
+	Progress     int    `json:"progress"`
+	Required     int    `json:"required"`
+	EncodedToken string `json:"encoded_token"`
+	OTP          string `json:"otp"`
+	OTPLength    int    `json:"otp_length"`
+	Complete     bool   `json:"complete"`
+}
+
+type tokenData struct {
+	Accessor string   `json:"accessor"`
+	Policies []string `json:"policies"`
+}
+
+type tokenLookupResponse struct {
+	Data tokenData `json:"data"`
+}
+
+type tokenAccessorListResponse struct {
+	Data struct {
+		Keys []string `json:"keys"`
+	} `json:"data"`
 }
 
 // UnsealRequest holds a Vault unseal request.
@@ -636,16 +663,37 @@ func persistBootstrapCompletion(store encryptedSecretStore, wait func(time.Durat
 }
 
 func enableAuditAndRevokeInitialRoot(rootToken string) error {
+	return enableAuditAndRevokeInitialRootWithWait(rootToken, time.Sleep)
+}
+
+func enableAuditAndRevokeInitialRootWithWait(rootToken string, wait func(time.Duration)) error {
 	if rootToken == "" {
 		return fmt.Errorf("initial root token is empty")
 	}
-	if err := ensureStdoutAuditDevice(rootToken); err != nil {
+	if err := retryEnsureStdoutAuditDevice(rootToken, wait); err != nil {
 		return err
 	}
 	if err := revokeInitialRootToken(rootToken); err != nil {
 		return err
 	}
 	return verifyInitialRootTokenRevoked(rootToken)
+}
+
+func retryEnsureStdoutAuditDevice(rootToken string, wait func(time.Duration)) error {
+	retryDelay := time.Second
+	var err error
+	for attempt := 1; attempt <= maxAuditAttempts; attempt++ {
+		if err = ensureStdoutAuditDevice(rootToken); err == nil {
+			return nil
+		}
+		if attempt == maxAuditAttempts {
+			break
+		}
+		log.Printf("Establishing the Vault stdout audit device failed; retrying in %s (attempt %d/%d): %v", retryDelay, attempt, maxAuditAttempts, err)
+		wait(retryDelay)
+		retryDelay = nextRetryDelay(retryDelay)
+	}
+	return fmt.Errorf("establish stdout audit device after %d attempts: %w", maxAuditAttempts, err)
 }
 
 func ensureStdoutAuditDevice(rootToken string) error {
@@ -928,6 +976,25 @@ func ensureInitializationTargetsEmpty(ctx context.Context, stat encryptedSecretS
 func verifyDurableInitialization() error {
 	ctx, cancel := context.WithTimeout(context.Background(), secretWriteTimeout)
 	defer cancel()
+	completionSize, err := statEncryptedSecret(ctx, bootstrapCompleteObjectName)
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		recovery, loadErr := loadIncompleteBootstrapRecovery(
+			ctx,
+			statEncryptedSecret,
+			readEncryptedSecret,
+			decryptSecretWithKMS,
+		)
+		if loadErr != nil {
+			return loadErr
+		}
+		return resumeIncompleteBootstrap(recovery, storeEncryptedSecretOnce, time.Sleep)
+	}
+	if err != nil {
+		return fmt.Errorf("inspect gs://%s/%s: %w", gcsBucketName, bootstrapCompleteObjectName, err)
+	}
+	if completionSize <= 0 {
+		return fmt.Errorf("gs://%s/%s is empty", gcsBucketName, bootstrapCompleteObjectName)
+	}
 	if err := verifyStoredRecoveryMaterial(ctx, statEncryptedSecret); err != nil {
 		return err
 	}
@@ -937,27 +1004,338 @@ func verifyDurableInitialization() error {
 	return verifyBootstrapCompletion(ctx, readEncryptedSecret)
 }
 
+func loadIncompleteBootstrapRecovery(
+	ctx context.Context,
+	stat encryptedSecretStat,
+	read encryptedSecretReader,
+	decrypt secretDecrypter,
+) (InitResponse, error) {
+	size, err := stat(ctx, unsealKeysObjectName)
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		return InitResponse{}, fmt.Errorf("gs://%s/%s is missing", gcsBucketName, unsealKeysObjectName)
+	}
+	if err != nil {
+		return InitResponse{}, fmt.Errorf("inspect gs://%s/%s: %w", gcsBucketName, unsealKeysObjectName, err)
+	}
+	if size <= 0 {
+		return InitResponse{}, fmt.Errorf("gs://%s/%s is empty", gcsBucketName, unsealKeysObjectName)
+	}
+
+	if size, err = stat(ctx, rootTokenObjectName); err == nil {
+		return InitResponse{}, fmt.Errorf("legacy gs://%s/%s still exists (%d bytes); refusing automatic bootstrap recovery", gcsBucketName, rootTokenObjectName, size)
+	} else if !errors.Is(err, storage.ErrObjectNotExist) {
+		return InitResponse{}, fmt.Errorf("inspect legacy gs://%s/%s: %w", gcsBucketName, rootTokenObjectName, err)
+	}
+
+	if _, err = stat(ctx, bootstrapCompleteObjectName); err == nil {
+		return InitResponse{}, fmt.Errorf("gs://%s/%s already exists; refusing incomplete-bootstrap recovery", gcsBucketName, bootstrapCompleteObjectName)
+	} else if !errors.Is(err, storage.ErrObjectNotExist) {
+		return InitResponse{}, fmt.Errorf("inspect gs://%s/%s: %w", gcsBucketName, bootstrapCompleteObjectName, err)
+	}
+
+	return readRecoveryBundleContents(ctx, read, decrypt)
+}
+
 func verifyRecoveryBundleContents(ctx context.Context, read encryptedSecretReader, decrypt secretDecrypter) error {
+	_, err := readRecoveryBundleContents(ctx, read, decrypt)
+	return err
+}
+
+func readRecoveryBundleContents(ctx context.Context, read encryptedSecretReader, decrypt secretDecrypter) (InitResponse, error) {
 	protectedResponse, err := read(ctx, unsealKeysObjectName)
 	if err != nil {
-		return fmt.Errorf("read encrypted recovery response: %w", err)
+		return InitResponse{}, fmt.Errorf("read encrypted recovery response: %w", err)
 	}
 	recoveryJSON, err := decrypt(ctx, protectedResponse)
 	if err != nil {
-		return fmt.Errorf("decrypt recovery response: %w", err)
+		return InitResponse{}, fmt.Errorf("decrypt recovery response: %w", err)
 	}
 	var recovery InitResponse
 	if err := json.Unmarshal(recoveryJSON, &recovery); err != nil {
-		return fmt.Errorf("decode recovery response: %w", err)
+		return InitResponse{}, fmt.Errorf("decode recovery response: %w", err)
 	}
 	if recovery.RootToken != "" {
-		return fmt.Errorf("encrypted recovery response retains an initial root token; migrate it to the root-token-free schema under dual control")
+		return InitResponse{}, fmt.Errorf("encrypted recovery response retains an initial root token; migrate it to the root-token-free schema under dual control")
 	}
 	if len(recovery.RecoveryKeys) == 0 && len(recovery.RecoveryKeysBase64) == 0 &&
 		len(recovery.Keys) == 0 && len(recovery.KeysBase64) == 0 {
-		return fmt.Errorf("encrypted recovery response contains no recovery or unseal keys")
+		return InitResponse{}, fmt.Errorf("encrypted recovery response contains no recovery or unseal keys")
+	}
+	return recovery, nil
+}
+
+func resumeIncompleteBootstrap(recovery InitResponse, store encryptedSecretStore, wait func(time.Duration)) (err error) {
+	if len(vaultRecoveryPGPKeys) != 0 {
+		return fmt.Errorf("automatic bootstrap recovery is unavailable when recovery shares use PGP custodian custody")
+	}
+	repairToken, err := generateRecoveryRootToken(recovery)
+	if err != nil {
+		return fmt.Errorf("generate temporary recovery root token: %w", err)
+	}
+	repairTokenLive := true
+	defer func() {
+		if !repairTokenLive {
+			return
+		}
+		if revokeErr := revokeInitialRootToken(repairToken); revokeErr != nil {
+			err = errors.Join(err, fmt.Errorf("revoke temporary recovery root token after recovery failure: %w", revokeErr))
+		}
+	}()
+
+	if err = retryEnsureStdoutAuditDevice(repairToken, wait); err != nil {
+		return err
+	}
+	if err = revokeOtherRootTokens(repairToken); err != nil {
+		return err
+	}
+	if err = revokeInitialRootToken(repairToken); err != nil {
+		return fmt.Errorf("revoke temporary recovery root token: %w", err)
+	}
+	if err = verifyInitialRootTokenRevoked(repairToken); err != nil {
+		return fmt.Errorf("verify temporary recovery root token revocation: %w", err)
+	}
+	repairTokenLive = false
+
+	if err = persistBootstrapCompletion(store, wait); err != nil {
+		return err
+	}
+	log.Println("Recovered incomplete secure bootstrap; audit is enabled and all root-policy tokens are revoked.")
+	return nil
+}
+
+func generateRecoveryRootToken(recovery InitResponse) (string, error) {
+	shares := recovery.RecoveryKeysBase64
+	if len(shares) == 0 {
+		shares = recovery.RecoveryKeys
+	}
+	if len(shares) == 0 {
+		return "", fmt.Errorf("KMS recovery bundle contains no Vault recovery keys")
+	}
+	if vaultRecoveryThreshold < 2 || vaultRecoveryThreshold > len(shares) {
+		return "", fmt.Errorf("configured recovery threshold %d is incompatible with %d stored recovery shares", vaultRecoveryThreshold, len(shares))
+	}
+	seenShares := make(map[string]struct{}, len(shares))
+	for _, share := range shares {
+		if strings.TrimSpace(share) == "" {
+			return "", fmt.Errorf("KMS recovery bundle contains an empty recovery share")
+		}
+		if _, duplicate := seenShares[share]; duplicate {
+			return "", fmt.Errorf("KMS recovery bundle contains duplicate recovery shares")
+		}
+		seenShares[share] = struct{}{}
+	}
+
+	status, body, err := doRootVaultRequest(http.MethodGet, "/v1/sys/generate-root/attempt", nil, "")
+	if err != nil {
+		return "", fmt.Errorf("inspect root generation attempt: %w", err)
+	}
+	if status != http.StatusOK {
+		return "", fmt.Errorf("inspect root generation attempt: unexpected status %d", status)
+	}
+	var current rootGenerationStatus
+	if err := json.Unmarshal(body, &current); err != nil {
+		return "", fmt.Errorf("decode root generation attempt: %w", err)
+	}
+	if current.Started {
+		status, _, err = doRootVaultRequest(http.MethodDelete, "/v1/sys/generate-root/attempt", nil, "")
+		if err != nil {
+			return "", fmt.Errorf("cancel stale root generation attempt: %w", err)
+		}
+		if status != http.StatusNoContent {
+			return "", fmt.Errorf("cancel stale root generation attempt: unexpected status %d", status)
+		}
+	}
+
+	status, body, err = doRootVaultRequest(http.MethodPost, "/v1/sys/generate-root/attempt", []byte("{}"), "")
+	if err != nil {
+		return "", fmt.Errorf("start root generation attempt: %w", err)
+	}
+	if status != http.StatusOK {
+		return "", fmt.Errorf("start root generation attempt: unexpected status %d", status)
+	}
+	var attempt rootGenerationStatus
+	if err := json.Unmarshal(body, &attempt); err != nil {
+		return "", fmt.Errorf("decode root generation start: %w", err)
+	}
+	if !attempt.Started || attempt.Nonce == "" || attempt.OTP == "" || attempt.OTPLength != len(attempt.OTP) || attempt.Complete {
+		return "", fmt.Errorf("root generation start returned an invalid nonce or OTP")
+	}
+	if attempt.Required != vaultRecoveryThreshold {
+		return "", fmt.Errorf("vault root generation requires %d shares, but configuration requires %d", attempt.Required, vaultRecoveryThreshold)
+	}
+
+	for _, share := range shares[:attempt.Required] {
+		payload, marshalErr := json.Marshal(map[string]string{"key": share, "nonce": attempt.Nonce})
+		if marshalErr != nil {
+			return "", fmt.Errorf("marshal root generation share: %w", marshalErr)
+		}
+		status, body, err = doRootVaultRequest(http.MethodPost, "/v1/sys/generate-root/update", payload, "")
+		if err != nil {
+			return "", fmt.Errorf("submit root generation share: %w", err)
+		}
+		if status != http.StatusOK {
+			return "", fmt.Errorf("submit root generation share: unexpected status %d", status)
+		}
+		var update rootGenerationStatus
+		if err := json.Unmarshal(body, &update); err != nil {
+			return "", fmt.Errorf("decode root generation update: %w", err)
+		}
+		if update.Nonce != attempt.Nonce || update.Required != attempt.Required {
+			return "", fmt.Errorf("root generation update changed nonce or threshold")
+		}
+		if !update.Complete {
+			continue
+		}
+		return decodeGeneratedRootToken(update.EncodedToken, attempt.OTP)
+	}
+	return "", fmt.Errorf("root generation did not complete after %d recovery shares", attempt.Required)
+}
+
+func decodeGeneratedRootToken(encodedToken, otp string) (string, error) {
+	encoded, err := base64.StdEncoding.DecodeString(encodedToken)
+	if err != nil {
+		return "", fmt.Errorf("decode generated root token: %w", err)
+	}
+	if len(encoded) == 0 || len(encoded) != len(otp) {
+		return "", fmt.Errorf("generated root token and OTP lengths do not match")
+	}
+	decoded := make([]byte, len(encoded))
+	for i := range encoded {
+		decoded[i] = encoded[i] ^ otp[i]
+	}
+	if strings.TrimSpace(string(decoded)) == "" {
+		return "", fmt.Errorf("generated root token is empty")
+	}
+	return string(decoded), nil
+}
+
+func revokeOtherRootTokens(repairToken string) error {
+	self, err := lookupSelfToken(repairToken)
+	if err != nil {
+		return fmt.Errorf("lookup temporary recovery root token: %w", err)
+	}
+	if self.Accessor == "" || !hasPolicy(self.Policies, "root") {
+		return fmt.Errorf("temporary recovery token is not a root-policy token")
+	}
+
+	accessors, err := listTokenAccessors(repairToken)
+	if err != nil {
+		return err
+	}
+	selfListed := false
+	for _, accessor := range accessors {
+		if accessor == self.Accessor {
+			selfListed = true
+			continue
+		}
+		token, lookupErr := lookupTokenAccessor(accessor, repairToken)
+		if lookupErr != nil {
+			return lookupErr
+		}
+		if !hasPolicy(token.Policies, "root") {
+			continue
+		}
+		if revokeErr := revokeTokenAccessor(accessor, repairToken); revokeErr != nil {
+			return revokeErr
+		}
+	}
+	if !selfListed {
+		return fmt.Errorf("temporary recovery root accessor was absent from the token accessor list")
+	}
+
+	accessors, err = listTokenAccessors(repairToken)
+	if err != nil {
+		return fmt.Errorf("verify root-token cleanup: %w", err)
+	}
+	for _, accessor := range accessors {
+		if accessor == self.Accessor {
+			continue
+		}
+		token, lookupErr := lookupTokenAccessor(accessor, repairToken)
+		if lookupErr != nil {
+			return fmt.Errorf("verify root-token cleanup: %w", lookupErr)
+		}
+		if hasPolicy(token.Policies, "root") {
+			return fmt.Errorf("verify root-token cleanup: root-policy token %q remains live", accessor)
+		}
 	}
 	return nil
+}
+
+func lookupSelfToken(rootToken string) (tokenData, error) {
+	status, body, err := doRootVaultRequest(http.MethodGet, "/v1/auth/token/lookup-self", nil, rootToken)
+	if err != nil {
+		return tokenData{}, err
+	}
+	if status != http.StatusOK {
+		return tokenData{}, fmt.Errorf("unexpected status %d", status)
+	}
+	var response tokenLookupResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return tokenData{}, fmt.Errorf("decode token lookup: %w", err)
+	}
+	return response.Data, nil
+}
+
+func listTokenAccessors(rootToken string) ([]string, error) {
+	status, body, err := doRootVaultRequest("LIST", "/v1/auth/token/accessors", nil, rootToken)
+	if err != nil {
+		return nil, fmt.Errorf("list token accessors: %w", err)
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("list token accessors: unexpected status %d", status)
+	}
+	var response tokenAccessorListResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decode token accessors: %w", err)
+	}
+	return response.Data.Keys, nil
+}
+
+func lookupTokenAccessor(accessor, rootToken string) (tokenData, error) {
+	payload, err := json.Marshal(map[string]string{"accessor": accessor})
+	if err != nil {
+		return tokenData{}, fmt.Errorf("marshal token accessor lookup: %w", err)
+	}
+	status, body, err := doRootVaultRequest(http.MethodPost, "/v1/auth/token/lookup-accessor", payload, rootToken)
+	if err != nil {
+		return tokenData{}, fmt.Errorf("lookup token accessor %q: %w", accessor, err)
+	}
+	if status != http.StatusOK {
+		return tokenData{}, fmt.Errorf("lookup token accessor %q: unexpected status %d", accessor, status)
+	}
+	var response tokenLookupResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return tokenData{}, fmt.Errorf("decode token accessor %q: %w", accessor, err)
+	}
+	if response.Data.Accessor != accessor {
+		return tokenData{}, fmt.Errorf("lookup token accessor %q returned accessor %q", accessor, response.Data.Accessor)
+	}
+	return response.Data, nil
+}
+
+func revokeTokenAccessor(accessor, rootToken string) error {
+	payload, err := json.Marshal(map[string]string{"accessor": accessor})
+	if err != nil {
+		return fmt.Errorf("marshal token accessor revocation: %w", err)
+	}
+	status, _, err := doRootVaultRequest(http.MethodPost, "/v1/auth/token/revoke-accessor", payload, rootToken)
+	if err != nil {
+		return fmt.Errorf("revoke root token accessor %q: %w", accessor, err)
+	}
+	if status != http.StatusNoContent {
+		return fmt.Errorf("revoke root token accessor %q: unexpected status %d", accessor, status)
+	}
+	return nil
+}
+
+func hasPolicy(policies []string, wanted string) bool {
+	for _, policy := range policies {
+		if policy == wanted {
+			return true
+		}
+	}
+	return false
 }
 
 func verifyBootstrapCompletion(ctx context.Context, read encryptedSecretReader) error {

--- a/main_test.go
+++ b/main_test.go
@@ -719,6 +719,363 @@ func TestSecureBootstrapEnablesAuditBeforeRevokingRoot(t *testing.T) {
 	}
 }
 
+func TestSecureBootstrapRetriesTransientAuditFailure(t *testing.T) {
+	originalVaultAddr := vaultAddr
+	originalHTTPClient := httpClient
+	originalMetadataClient := metadataClient
+	t.Cleanup(func() {
+		vaultAddr = originalVaultAddr
+		httpClient = originalHTTPClient
+		metadataClient = originalMetadataClient
+	})
+
+	metadataClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"proxy-admin"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	auditReads := 0
+	rootRevoked := false
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.Method + " " + request.URL.Path {
+		case "GET /v1/sys/audit":
+			auditReads++
+			if auditReads == 1 {
+				response.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_, _ = response.Write([]byte(`{"cloudrun/":{"type":"file","options":{"file_path":"stdout","log_raw":"false"}}}`))
+		case "POST /v1/auth/token/revoke-self":
+			rootRevoked = true
+			response.WriteHeader(http.StatusNoContent)
+		case "GET /v1/auth/token/lookup-self":
+			if rootRevoked {
+				response.WriteHeader(http.StatusForbidden)
+				return
+			}
+			response.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected Vault request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+	vaultAddr = server.URL
+	httpClient = server.Client()
+
+	var waits []time.Duration
+	if err := enableAuditAndRevokeInitialRootWithWait("initial-root", func(delay time.Duration) {
+		waits = append(waits, delay)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(waits, []time.Duration{time.Second}) {
+		t.Fatalf("retry waits = %v, want [1s]", waits)
+	}
+}
+
+func TestLoadIncompleteBootstrapRecoveryRequiresExactKMSState(t *testing.T) {
+	validBundle := []byte(`{"recovery_keys_base64":["one","two","three"]}`)
+	tests := []struct {
+		name      string
+		sizes     map[string]int64
+		errors    map[string]error
+		wantError string
+	}{
+		{
+			name:  "root-free bundle without completion",
+			sizes: map[string]int64{unsealKeysObjectName: 512},
+		},
+		{
+			name:      "completion already exists",
+			sizes:     map[string]int64{unsealKeysObjectName: 512, bootstrapCompleteObjectName: 128},
+			wantError: "already exists",
+		},
+		{
+			name:      "legacy root token exists",
+			sizes:     map[string]int64{unsealKeysObjectName: 512, rootTokenObjectName: 64},
+			wantError: rootTokenObjectName + " still exists",
+		},
+		{
+			name:      "recovery bundle missing",
+			wantError: unsealKeysObjectName + " is missing",
+		},
+		{
+			name:      "completion lookup failed",
+			sizes:     map[string]int64{unsealKeysObjectName: 512},
+			errors:    map[string]error{bootstrapCompleteObjectName: errors.New("storage unavailable")},
+			wantError: "storage unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stat := func(_ context.Context, name string) (int64, error) {
+				if err := tt.errors[name]; err != nil {
+					return 0, err
+				}
+				if size, ok := tt.sizes[name]; ok {
+					return size, nil
+				}
+				return 0, storage.ErrObjectNotExist
+			}
+			recovery, err := loadIncompleteBootstrapRecovery(
+				context.Background(),
+				stat,
+				func(context.Context, string) ([]byte, error) { return []byte("encrypted"), nil },
+				func(context.Context, []byte) ([]byte, error) { return validBundle, nil },
+			)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(recovery.RecoveryKeysBase64, []string{"one", "two", "three"}) {
+					t.Fatalf("recovery = %#v", recovery)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("error = %v, want text %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestDecodeGeneratedRootToken(t *testing.T) {
+	token := []byte("repair-root-token")
+	otp := []byte("0123456789ABCDEFG")
+	encoded := make([]byte, len(token))
+	for i := range token {
+		encoded[i] = token[i] ^ otp[i]
+	}
+
+	got, err := decodeGeneratedRootToken(base64.StdEncoding.EncodeToString(encoded), string(otp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != string(token) {
+		t.Fatalf("token = %q, want %q", got, token)
+	}
+	if _, err := decodeGeneratedRootToken(base64.StdEncoding.EncodeToString(encoded[:len(encoded)-1]), string(otp)); err == nil {
+		t.Fatal("mismatched OTP and encoded token lengths were accepted")
+	}
+}
+
+func TestResumeIncompleteKMSBootstrap(t *testing.T) {
+	originalVaultAddr := vaultAddr
+	originalHTTPClient := httpClient
+	originalMetadataClient := metadataClient
+	originalShares := vaultRecoveryShares
+	originalThreshold := vaultRecoveryThreshold
+	originalPGPKeys := vaultRecoveryPGPKeys
+	t.Cleanup(func() {
+		vaultAddr = originalVaultAddr
+		httpClient = originalHTTPClient
+		metadataClient = originalMetadataClient
+		vaultRecoveryShares = originalShares
+		vaultRecoveryThreshold = originalThreshold
+		vaultRecoveryPGPKeys = originalPGPKeys
+	})
+	vaultRecoveryShares = 5
+	vaultRecoveryThreshold = 3
+	vaultRecoveryPGPKeys = nil
+
+	metadataClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"proxy-admin"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	repairToken := []byte("repair-root-token")
+	otp := []byte("0123456789ABCDEFG")
+	encodedToken := make([]byte, len(repairToken))
+	for i := range repairToken {
+		encodedToken[i] = repairToken[i] ^ otp[i]
+	}
+
+	staleAttempt := true
+	rootGenerationStarted := false
+	rootGenerationComplete := false
+	auditEnabled := false
+	initialRootLive := true
+	repairRootLive := true
+	sharesProvided := 0
+	var events []string
+
+	writeJSON := func(response http.ResponseWriter, value any) {
+		response.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(response).Encode(value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("X-Admin-Token") != "proxy-admin" {
+			t.Errorf("%s %s omitted X-Admin-Token", request.Method, request.URL.Path)
+		}
+		isGenerationRequest := strings.HasPrefix(request.URL.Path, "/v1/sys/generate-root/")
+		if isGenerationRequest && request.Header.Get("X-Vault-Token") != "" {
+			t.Errorf("root generation unexpectedly carried a Vault token")
+		}
+		if !isGenerationRequest && request.Header.Get("X-Vault-Token") != string(repairToken) {
+			t.Errorf("%s %s used the wrong repair token", request.Method, request.URL.Path)
+		}
+
+		switch request.Method + " " + request.URL.Path {
+		case "GET /v1/sys/generate-root/attempt":
+			writeJSON(response, map[string]any{"started": staleAttempt})
+		case "DELETE /v1/sys/generate-root/attempt":
+			events = append(events, "cancel stale generation")
+			staleAttempt = false
+			response.WriteHeader(http.StatusNoContent)
+		case "POST /v1/sys/generate-root/attempt":
+			events = append(events, "start generation")
+			rootGenerationStarted = true
+			writeJSON(response, map[string]any{
+				"started": true, "nonce": "repair-nonce", "otp": string(otp),
+				"otp_length": len(otp), "required": 3, "complete": false,
+			})
+		case "POST /v1/sys/generate-root/update":
+			if !rootGenerationStarted {
+				t.Error("recovery share submitted before root generation started")
+			}
+			var payload map[string]string
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload["nonce"] != "repair-nonce" || payload["key"] == "" {
+				t.Errorf("invalid recovery share payload %#v", payload)
+			}
+			sharesProvided++
+			events = append(events, "provide recovery share")
+			rootGenerationComplete = sharesProvided == 3
+			result := map[string]any{
+				"started": true, "nonce": "repair-nonce", "progress": sharesProvided,
+				"required": 3, "complete": rootGenerationComplete,
+			}
+			if rootGenerationComplete {
+				result["encoded_token"] = base64.StdEncoding.EncodeToString(encodedToken)
+			}
+			writeJSON(response, result)
+		case "GET /v1/sys/audit":
+			if !auditEnabled {
+				writeJSON(response, map[string]any{})
+				return
+			}
+			writeJSON(response, map[string]any{
+				"cloudrun/": map[string]any{
+					"type": "file", "options": map[string]string{"file_path": "stdout", "log_raw": "false"},
+				},
+			})
+		case "POST /v1/sys/audit/cloudrun":
+			events = append(events, "enable audit")
+			auditEnabled = true
+			response.WriteHeader(http.StatusNoContent)
+		case "GET /v1/auth/token/lookup-self":
+			if !repairRootLive {
+				response.WriteHeader(http.StatusForbidden)
+				return
+			}
+			writeJSON(response, map[string]any{"data": map[string]any{
+				"accessor": "repair-accessor", "policies": []string{"root"},
+			}})
+		case "LIST /v1/auth/token/accessors":
+			accessors := []string{"repair-accessor", "application-accessor"}
+			if initialRootLive {
+				accessors = append(accessors, "initial-root-accessor")
+			}
+			writeJSON(response, map[string]any{"data": map[string]any{"keys": accessors}})
+		case "POST /v1/auth/token/lookup-accessor":
+			var payload map[string]string
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			policies := []string{"default"}
+			if payload["accessor"] == "initial-root-accessor" {
+				policies = []string{"root"}
+			}
+			writeJSON(response, map[string]any{"data": map[string]any{
+				"accessor": payload["accessor"], "policies": policies,
+			}})
+		case "POST /v1/auth/token/revoke-accessor":
+			if !auditEnabled {
+				t.Error("initial root was revoked before audit was enabled")
+			}
+			var payload map[string]string
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload["accessor"] != "initial-root-accessor" {
+				t.Errorf("unexpected revoked accessor %q", payload["accessor"])
+			}
+			events = append(events, "revoke orphan root")
+			initialRootLive = false
+			response.WriteHeader(http.StatusNoContent)
+		case "POST /v1/auth/token/revoke-self":
+			if !auditEnabled || initialRootLive {
+				t.Error("repair root was revoked before audited orphan-root cleanup")
+			}
+			events = append(events, "revoke repair root")
+			repairRootLive = false
+			response.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected Vault request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+	vaultAddr = server.URL
+	httpClient = server.Client()
+
+	var completion []byte
+	err := resumeIncompleteBootstrap(
+		InitResponse{RecoveryKeysBase64: []string{"one", "two", "three", "four", "five"}},
+		func(_ context.Context, name string, data []byte) error {
+			if initialRootLive || repairRootLive || !auditEnabled {
+				t.Fatal("completion was stored before audited root-token cleanup")
+			}
+			if name != bootstrapCompleteObjectName {
+				t.Fatalf("stored object = %q", name)
+			}
+			events = append(events, "store completion")
+			completion = bytes.Clone(data)
+			return nil
+		},
+		func(time.Duration) { t.Fatal("unexpected retry wait") },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if staleAttempt || !rootGenerationComplete || initialRootLive || repairRootLive {
+		t.Fatalf("recovery state stale=%t complete=%t initialRootLive=%t repairRootLive=%t", staleAttempt, rootGenerationComplete, initialRootLive, repairRootLive)
+	}
+	if len(completion) == 0 {
+		t.Fatal("completion marker was not stored")
+	}
+	if events[len(events)-1] != "store completion" {
+		t.Fatalf("events = %v", events)
+	}
+}
+
+func TestResumeIncompleteBootstrapRejectsPGPCustody(t *testing.T) {
+	originalKeys := vaultRecoveryPGPKeys
+	t.Cleanup(func() { vaultRecoveryPGPKeys = originalKeys })
+	vaultRecoveryPGPKeys = testRecoveryPGPKeys()
+	err := resumeIncompleteBootstrap(
+		InitResponse{RecoveryKeysBase64: []string{"encrypted-share"}},
+		func(context.Context, string, []byte) error {
+			t.Fatal("completion was stored for PGP custody")
+			return nil
+		},
+		func(time.Duration) { t.Fatal("unexpected retry wait") },
+	)
+	if err == nil || !strings.Contains(err.Error(), "PGP") {
+		t.Fatalf("error = %v, want PGP refusal", err)
+	}
+}
+
 func TestPreflightInitializationChecksTargetsBeforeKMS(t *testing.T) {
 	encryptCalls := 0
 	stat := func(_ context.Context, name string) (int64, error) {


### PR DESCRIPTION
## Summary
- retry transient audit-device setup while the initial root remains in memory
- resume the exact KMS/GCS state where recovery material exists but the completion marker does not
- generate a temporary recovery root through Vault, preserve non-root tokens, revoke orphan root-policy tokens, and write the completion marker last
- refuse automated recovery for PGP custody, legacy root-token objects, or ambiguous storage states

## Validation
- `go test ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `git diff --check`
- `docker build --pull=false -t vault-init:resume-ci .`

Hosted CI provides the race and lint gates because this host does not include a C compiler.