### PR TITLE
[patch] Decode Vault raw root token encoding

### DIFF
--- a/main.go
+++ b/main.go
@@ -1192,7 +1192,7 @@ func generateRecoveryRootToken(recovery InitResponse) (string, error) {
 }
 
 func decodeGeneratedRootToken(encodedToken, otp string) (string, error) {
-	encoded, err := base64.StdEncoding.DecodeString(encodedToken)
+	encoded, err := base64.RawStdEncoding.DecodeString(encodedToken)
 	if err != nil {
 		return "", fmt.Errorf("decode generated root token: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -851,14 +851,14 @@ func TestDecodeGeneratedRootToken(t *testing.T) {
 		encoded[i] = token[i] ^ otp[i]
 	}
 
-	got, err := decodeGeneratedRootToken(base64.StdEncoding.EncodeToString(encoded), string(otp))
+	got, err := decodeGeneratedRootToken(base64.RawStdEncoding.EncodeToString(encoded), string(otp))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got != string(token) {
 		t.Fatalf("token = %q, want %q", got, token)
 	}
-	if _, err := decodeGeneratedRootToken(base64.StdEncoding.EncodeToString(encoded[:len(encoded)-1]), string(otp)); err == nil {
+	if _, err := decodeGeneratedRootToken(base64.RawStdEncoding.EncodeToString(encoded[:len(encoded)-1]), string(otp)); err == nil {
 		t.Fatal("mismatched OTP and encoded token lengths were accepted")
 	}
 }
@@ -957,7 +957,7 @@ func TestResumeIncompleteKMSBootstrap(t *testing.T) {
 				"required": 3, "complete": rootGenerationComplete,
 			}
 			if rootGenerationComplete {
-				result["encoded_token"] = base64.StdEncoding.EncodeToString(encodedToken)
+				result["encoded_token"] = base64.RawStdEncoding.EncodeToString(encodedToken)
 			}
 			writeJSON(response, result)
 		case "GET /v1/sys/audit":


### PR DESCRIPTION
## Summary

- decode generated recovery root tokens with the unpadded standard Base64 encoding emitted by Vault
- exercise the decoder and interrupted-bootstrap recovery path with Vault-compatible wire values

## Evidence

- go test ./... -count=1
- go vet ./...
- HashiCorp Vault sdk/helper/roottoken.EncodeToken uses base64.RawStdEncoding

## Safety

The temporary root token remains memory-only and is revoked by the existing recovery flow. No recovery material is logged or persisted outside the existing KMS-encrypted bundle.