### PR TITLE
Fix Vault audit response decoding

### DIFF
--- a/main.go
+++ b/main.go
@@ -746,10 +746,20 @@ func readAuditDevices(rootToken string) (map[string]auditDevice, error) {
 		return nil, fmt.Errorf("unexpected status %d", status)
 	}
 	var devices map[string]auditDevice
-	if err := json.Unmarshal(body, &devices); err != nil {
-		return nil, fmt.Errorf("decode audit devices: %w", err)
+	directErr := json.Unmarshal(body, &devices)
+	if directErr == nil {
+		return devices, nil
 	}
-	return devices, nil
+	var response struct {
+		Data map[string]auditDevice `json:"data"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decode audit devices response: %w", err)
+	}
+	if response.Data == nil {
+		return nil, fmt.Errorf("decode audit devices: %w", directErr)
+	}
+	return response.Data, nil
 }
 
 func validateStdoutAuditDevice(device auditDevice) error {

--- a/main_test.go
+++ b/main_test.go
@@ -684,7 +684,7 @@ func TestSecureBootstrapEnablesAuditBeforeRevokingRoot(t *testing.T) {
 				_, _ = response.Write([]byte(`{}`))
 				return
 			}
-			_, _ = response.Write([]byte(`{"cloudrun/":{"type":"file","options":{"file_path":"stdout","log_raw":"false"}}}`))
+			_, _ = response.Write([]byte(`{"request_id":"audit-list","lease_id":"","renewable":false,"lease_duration":0,"data":{"cloudrun/":{"type":"file","options":{"file_path":"stdout","log_raw":"false"}}},"wrap_info":null,"warnings":null,"auth":null,"mount_type":"system"}`))
 		case "POST /v1/sys/audit/cloudrun":
 			events = append(events, "audit")
 			auditEnabled = true


### PR DESCRIPTION
## Summary

- decode Vault audit listings returned inside the standard response data envelope
- preserve compatibility with direct audit-device maps
- cover the production response shape in the secure bootstrap behavior test

## Verification

- `go test ./... -run "^TestSecureBootstrapEnablesAuditBeforeRevokingRoot$" -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`