### PR TITLE
Fix Vault token accessor listing through Cloud Run

### DIFF
--- a/main.go
+++ b/main.go
@@ -1288,7 +1288,7 @@ func lookupSelfToken(rootToken string) (tokenData, error) {
 }
 
 func listTokenAccessors(rootToken string) ([]string, error) {
-	status, body, err := doRootVaultRequest("LIST", "/v1/auth/token/accessors", nil, rootToken)
+	status, body, err := doRootVaultRequest(http.MethodGet, "/v1/auth/token/accessors?list=true", nil, rootToken)
 	if err != nil {
 		return nil, fmt.Errorf("list token accessors: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -982,7 +982,10 @@ func TestResumeIncompleteKMSBootstrap(t *testing.T) {
 			writeJSON(response, map[string]any{"data": map[string]any{
 				"accessor": "repair-accessor", "policies": []string{"root"},
 			}})
-		case "LIST /v1/auth/token/accessors":
+		case "GET /v1/auth/token/accessors":
+			if request.URL.Query().Get("list") != "true" {
+				t.Fatalf("token accessor request omitted list=true: %s", request.URL.RawQuery)
+			}
 			accessors := []string{"repair-accessor", "application-accessor"}
 			if initialRootLive {
 				accessors = append(accessors, "initial-root-accessor")


### PR DESCRIPTION
## Summary
- use Vault’s standard GET `?list=true` token-accessor listing form so Cloud Run forwards the request
- keep the existing X-Admin-Token and generated recovery root-token contract unchanged
- cover the complete incomplete-bootstrap recovery flow with the Cloud Run-compatible request shape

## Verification
- `go test . -run ^TestResumeIncompleteKMSBootstrap$ -count=1`
- `go test ./... -count=1`
- `go vet ./...`

## Production evidence
Vault Init 1.2.4 completed root generation and audit setup through the customer Vault Proxy, but repeated `LIST /v1/auth/token/accessors` as an upstream 502. Cloud Run request logs contain no delivered LIST request; standard GET/POST requests before and after it were delivered successfully.