### PR TITLE
[patch] Let the LibOps builder tag float

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/libops/go:1.26.6@sha256:132e5632829827a10da523e64a2adaed4c47362e60ac26f081181d7c7a279bb8 AS builder
+FROM ghcr.io/libops/go:1.26.6 AS builder
 
 SHELL ["/bin/ash", "-o", "pipefail", "-ex", "-c"]
 


### PR DESCRIPTION
Removes the checked-in digest pin from the LibOps-owned Go builder image while retaining its release tag. Renovate remains responsible for external dependency pins; runtime release evidence may still record exact digests.

Validation:
- `docker build --check .`
- `go test ./...`
- `go vet ./...`