### PR TITLE
Remove Trivy image scanning

### DIFF
--- a/.github/workflows/lint-test-build-push.yml
+++ b/.github/workflows/lint-test-build-push.yml
@@ -79,16 +79,6 @@ jobs:
           push: false
           tags: vault-init:ci-${{ matrix.architecture.suffix }}
 
-      - name: Scan native image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: vault-init:ci-${{ matrix.architecture.suffix }}
-          format: table
-          exit-code: "1"
-          ignore-unfixed: true
-          severity: HIGH,CRITICAL
-          vuln-type: os,library
-
   build-push:
     if: always() && github.event_name == 'pull_request'
     needs:
@@ -107,7 +97,6 @@ jobs:
       ref: ${{ github.sha }}
       expected-main-sha: ${{ github.ref == 'refs/heads/main' && github.sha || '' }}
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
-      scan: true
       sign: true
     permissions:
       contents: read


### PR DESCRIPTION
Removes Trivy from native-image validation and the shared publisher call. Existing dependency audits, contract tests, SBOM generation, signing, provenance, and digest verification remain in place.